### PR TITLE
Improve grammar/wording, and add paragraph on string coercion pitfalls

### DIFF
--- a/deprecate-bool-type-juggling-function-context.md
+++ b/deprecate-bool-type-juggling-function-context.md
@@ -1,4 +1,4 @@
-# PHP RFC: Deprecate type juggling from and to bool type within the function type juggling context
+# PHP RFC: Deprecate type juggling to and from bool type within the function type juggling context
 
 - Version: 0.1
 - Date: 2025-01-DD
@@ -13,18 +13,18 @@
 PHP has a few type juggling contexts which are described on the
 [Type Juggling](https://www.php.net/manual/en/language.types.type-juggling.php)
 documentation page.
-The function type juggling context refers to the type juggling that occurs
+The function type juggling context refers to the type coercion that occurs
 when passing a value to a function/method argument, returning a value from
 a function/argument with a return type, and assigning a value to a typed property.
 
 In this context only scalar (`int`, `float`, `string`, and `bool`) types can be type juggled.
 However, type juggling to the singleton types `true` and `false` is not possible. 
-Moreover, it is possible to prevent type juggling of scalar types (except for widening of `int` to `float`)
+Moreover, it is possible to prevent coercion of scalar types (except for widening of `int` to `float`)
 in this context altogether by using the
 [`strict_types=1`](https://www.php.net/manual/en/language.types.declarations.php#language.types.declarations.strict)
 declare statement in a file.
 
-The topic about the behaviour of type juggling to and from `bool` has been discussed various times.
+The behaviour of type juggling to and from `bool` has been discussed various times.
 First in the controversial
 [Coercive Types for Function Arguments](https://wiki.php.net/rfc/coercive_sth)
 RFC from Zend Technologies et al. in 2015 which was "competing" with the - accepted -
@@ -33,15 +33,20 @@ RFC from Anthony Ferrara (based on prior work from Andrea Faulds).
 The RFC from Zend Technologies et al. proposed to ban type juggling from `float` to `bool`. [1]
 We could not determine what lead to this choice in both discussion threads, [2] [3]
 however the reply from Pierre Joye [4] may be part of the reason.
-Currently only the `float` values `-0.0` and `0.0` are implicitly converted to `false`.
-Moreover, this means `NAN` is converted to `true`,
-which leads to a different behaviour when `NAN` is cast to `int` and then to `bool`
-(as `(int) NAN === 0`).
-It is also common to deal with floating point numbers that are _close_ to `0` but not exactly 0,
-which compounded with the _generally_ known fact that comparing floats is tricky, [5]
-one might wonder how sensible it is to allow implicit conversions from `float` to `bool`.
 
-In 2020, this topic was briefly approached was Nikita Popov's
+Currently only the `float` values `-0.0` and `0.0` are implicitly converted to `false`.
+This means `NAN` is converted to `true`,
+which leads to different behaviour when `NAN` is first cast to `int` and then to `bool`
+(as `(int) NAN === 0`, which is converted to `false`).
+It is also common to deal with floating point numbers that are _close_ to `0` but not exactly zero,
+which compounded with the _generally_ known fact that comparing floats is tricky, [5]
+calls into question how sensible it is to allow implicit conversions from `float` to `bool`.
+
+Type juggling of strings to `bool` is similarly error-prone. The strings `""` and `"0"`
+are converted to `false`, but `"false"`, `" "`, and other strings which an `(int)` cast converts to `0`
+are coerced to `true`.
+
+In 2020, this topic was briefly approached by Nikita Popov's
 [Union Types 2.0](https://wiki.php.net/rfc/union_types_v2)
 RFC, which laid down the behavioural semantics of scalar union types in coercive typing mode.
 It also excluded implicit coercion to the singleton types `null` and `false`.
@@ -52,11 +57,11 @@ will convert to another scalar type if it is part of the union type before defau
 
 In 2021, the proposal to
 [Deprecate boolean to string coercion](https://wiki.php.net/rfc/deprecate-boolean-string-coercion)
-was brought to internals by Ilija Tovilo and ourselves.
+was brought to internals by Ilija Tovilo and myself.
 This proposal suggested deprecating implicit coercions from `bool` to `string`.
-Those can only happen in two type juggling contexts, the function one, and the string one.
-The latter refers to displaying output via `echo` or `print`, string concatenation, and string interpolation.
-As the impact from deprecating `bool` to `string` conversion was high, notably within php-src`s own test suite,
+Those can only happen in two type juggling contexts: the function one, and the string one
+(the latter refers to displaying output via `echo` or `print`, string concatenation, and string interpolation).
+As the impact from deprecating `bool` to `string` conversion was high, notably within php-src's own test suite,
 we did not bring this proposal to a vote.
 
 In 2022, we proposed to add the
@@ -78,15 +83,15 @@ and values for INI settings accept a wider set of values.
 
 ## Proposal
 
-We propose to deprecate type coercions from and to `bool` types in the
+We propose to deprecate type coercions to and from `bool` in the
 function type juggling context.
 Providing a boolean value to a parameter/property of a different type very likely points to a programming bug.
-And as we have seen coercing `string` and `float` values to `bool` is somewhat dubious in nature
-due to different domain logics treating these values differently.
-The on implicit coercion that makes sense most of the time, is the one from `int` to `bool`,
-but for consistency’s sake we believe this should also be deprecated.
+And as we have seen, coercing `string` and `float` values to `bool` is somewhat dubious in nature
+since these values are usually handled with different logic in different domains.
+The only implicit coercion that makes sense most of the time is the one from `int` to `bool`,
+but for consistency's sake we believe this should also be deprecated.
 
-The long term benefits of this proposal are as following:
+The long term benefits of this proposal are the following:
 
 - The union type `true|false` is identical to `bool`
 - A potential unification of PHP's typing modes [6]


### PR DESCRIPTION
@Girgias I'm not sure what you think about the added paragraph. I added it since later in the RFC it states,

> as we have seen, coercing `string` and `float` values to `bool` is somewhat dubious in nature

but I didn't see any examples before showing why it is dubious.